### PR TITLE
Install ninja as a build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "scikit-build"]
+requires = ["setuptools>=42", "wheel", "scikit-build", "ninja"]
 
 [tool.cibuildwheel]
 # Super-verbose output for debugging purpose


### PR DESCRIPTION
This will make scikit-build prefer ninja, which automatically leverages the available 2 cores.