### PR TITLE
docs: minor README update and remove completed TODO list

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,13 @@ A [pre-commit](https://pre-commit.com) hook is also [provided](https://github.co
 
 ## Building new releases
 
-The [clang-format-wheel repository](https://github.com/ssciwr/clang-format-wheel) provides the build logic to build and publish binary wheels of the `clang-format` utility.
+The [clang-format-wheel repository](https://github.com/ssciwr/clang-format-wheel) provides the logic to build and publish binary wheels of the `clang-format` utility.
 
 In order to add a new release, the following steps are necessary:
 
 * Edit the [version file](https://github.com/ssciwr/clang-format-wheel/blob/main/clang-format_version.cmake) to reflect the new version.
 * Make a GitHub release to trigger the [GitHub Actions release workflow](https://github.com/ssciwr/clang-format-wheel/actions/workflows/release.yml). Alternatively, the workflow can be triggered manually.
+* Update and tag a new version for the [clang-format-precommit](https://github.com/ssciwr/clang-format-precommit) hook.
 
 On manual triggers, the following input variables are available:
 * `use_qemu`: Whether to build targets that require emulation (default: `true`)
@@ -39,7 +40,7 @@ On manual triggers, the following input variables are available:
 
 This repository extends the great work of several other projects:
 
-* `clang-format` itself is [provided by the LLVM project](https://github.com/llvm/llvm-project) under the Apache 2.0 license with exceptions.
+* `clang-format` itself is [provided by the LLVM project](https://github.com/llvm/llvm-project) under the Apache 2.0 License with LLVM exceptions.
 * The build logic is based on [scikit-build](https://github.com/scikit-build/scikit-build) which greatly reduces the amount of low level code necessary to package `clang-format`.
 * The `scikit-build` packaging examples of [CMake](https://github.com/scikit-build/cmake-python-distributions) and [Ninja](https://github.com/scikit-build/ninja-python-distributions) were very helpful in packaging `clang-format`.
 * The CI build process is controlled by [cibuildwheel](https://github.com/pypa/cibuildwheel) which makes building wheels across a number of platforms a pleasant experience (!)

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,0 @@
-# Blockers
-
-* Switch to actual versions by using get_version in setup.py
-* Propose changes in mgevaert repository
-* Transition from TestPyPI to PyPI
-
-# Minor stuff
-
-* Finalize README.md


### PR DESCRIPTION
- remove the completed TODO list
- add updating clang-format-precommit hook step to release process
- match info on LLVM license name with the name the LLVM project uses for it (https://llvm.org/docs/DeveloperPolicy.html#new-llvm-project-license-framework)