### PR TITLE
Switch from git clone to downloading a LLVM source archive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,12 +3,13 @@ cmake_minimum_required(VERSION 3.16)
 
 # Include the "single source of truth" for the clang-format version
 include(clang-format_version.cmake)
+string(REPLACE "-" "" CLANG_FORMAT_VERSION_SHORT "${CLANG_FORMAT_VERSION}")
 
 # Define a build rule clang-format
+set(LLVM_DOWNLOAD_URL "https://github.com/llvm/llvm-project/releases/download/llvmorg-${CLANG_FORMAT_VERSION}/llvm-project-${CLANG_FORMAT_VERSION_SHORT}.src.tar.xz")
 include(ExternalProject)
 ExternalProject_add(build-clang-format
-  GIT_REPOSITORY https://github.com/llvm/llvm-project
-  GIT_TAG llvmorg-${CLANG_FORMAT_VERSION}
+  URL "${LLVM_DOWNLOAD_URL}"
   SOURCE_SUBDIR llvm
   SOURCE_DIR ${CMAKE_BINARY_DIR}/llvm-project
   BINARY_DIR ${CMAKE_BINARY_DIR}/llvm


### PR DESCRIPTION
This speeds up getting the source code for LLVM by an order of magnitude. Git cloning the LLVM repository takes several minutes for the native builds on GitHub Actions (and on my computer with gigabit fiber). A shallow clone takes ~42 seconds, whereas downloading and extracting the LLVM source archive takes 10 seconds.

The GitHub Actions VMs don't have the most consistent build times; for the native x86 builds on Linux/macOS/Windows this change seems to shave off 3-4 minutes, with both the i686/x86_64 Linux builds and the test build of the source dist archive taking right around 10 minutes after this change.

For the emulated qemu builds on arm and s390x this could be reducing the build time by 30-60 minutes; after the change I saw their build times drop below 2 hours. The ppc64le build time doesn't seem to change all that much.

---

I'm not sure what affects this has as far firewalls go, though I know at least the piwheels.org builders aren't able to git clone repositories (resource saving measure?); it's possible that this change could also enable piwheels.org to successfully build Raspberry Pi specific wheels from the clang-format-wheel sdist on PyPI.