### PR TITLE
Update clang-format precommit hook name

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ In order to add a new release, the following steps are necessary:
 
 * Edit the [version file](https://github.com/ssciwr/clang-format-wheel/blob/main/clang-format_version.cmake) to reflect the new version.
 * Make a GitHub release to trigger the [GitHub Actions release workflow](https://github.com/ssciwr/clang-format-wheel/actions/workflows/release.yml). Alternatively, the workflow can be triggered manually.
-* Update and tag a new version for the [clang-format-hook](https://github.com/ssciwr/clang-format-hook) hook.
+* Update and tag a new version for [clang-format-hook](https://github.com/ssciwr/clang-format-hook).
 
 On manual triggers, the following input variables are available:
 * `use_qemu`: Whether to build targets that require emulation (default: `true`)

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ You can use `pipx` to run clang-format, as well. For example, `pipx run clang-fo
 
 ## Use from pre-commit
 
-A [pre-commit](https://pre-commit.com) hook is also [provided](https://github.com/ssciwr/clang-format-precommit), use like this:
+A [pre-commit](https://pre-commit.com) hook is also [provided](https://github.com/ssciwr/clang-format-hook), use like this:
 
 ```yaml
-- repo: https://github.com/ssciwr/clang-format-precommit
+- repo: https://github.com/ssciwr/clang-format-hook
   rev: v13.0.0
   hooks:
   - id: clang-format
@@ -33,7 +33,7 @@ In order to add a new release, the following steps are necessary:
 
 * Edit the [version file](https://github.com/ssciwr/clang-format-wheel/blob/main/clang-format_version.cmake) to reflect the new version.
 * Make a GitHub release to trigger the [GitHub Actions release workflow](https://github.com/ssciwr/clang-format-wheel/actions/workflows/release.yml). Alternatively, the workflow can be triggered manually.
-* Update and tag a new version for the [clang-format-precommit](https://github.com/ssciwr/clang-format-precommit) hook.
+* Update and tag a new version for the [clang-format-hook](https://github.com/ssciwr/clang-format-hook) hook.
 
 On manual triggers, the following input variables are available:
 * `use_qemu`: Whether to build targets that require emulation (default: `true`)


### PR DESCRIPTION
Updates instances of the renamed `clang-format-precommit` to `clang-format-hook`.