### PR TITLE
Specify minimum cmake version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "scikit-build", "ninja"]
+requires = ["setuptools>=42", "wheel", "scikit-build", "cmake>=3.16", "ninja"]
 
 [tool.cibuildwheel]
 # Super-verbose output for debugging purpose


### PR DESCRIPTION
* Specifies cmake>=3.16 following the instructions in the scikit-build documentation to ensure that a version of cmake that can build clang-format is installed along with the build dependencies.
* Otherwise, we can run into errors like so when trying to build clang-format from source: 
```CMake Error at CMakeLists.txt:2 (cmake_minimum_required):
        CMake 3.16 or higher is required.  You are running version 3.14.0
```
Related to #17 