### PR TITLE
Have the build process depend on the correct CMake version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "scikit-build", "ninja"]
+requires = ["setuptools>=42", "wheel", "scikit-build", "cmake>=3.16", "ninja"]
 
 [tool.cibuildwheel]
 # Super-verbose output for debugging purpose


### PR DESCRIPTION
I briefly thought about following the procedure outline here, but dismissed the idea because it does not offer substantial benefits IMO: https://scikit-build.readthedocs.io/en/latest/usage.html#adding-cmake-as-building-requirement-only-if-not-installed-or-too-low-a-version 

First part of fixes for #17 