### PR TITLE
Remove GH release trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,9 @@ on:
         description: "Whether the build should be deployed to test.pypi.org instead regular PyPI"
         required: true
         default: false
-  release:
-    types:
-      - published
 
 env:
-  USE_QEMU: ${{ (github.event.inputs.use_qemu == 'true') || (github.event.action == 'published') }}
+  USE_QEMU: ${{ github.event.inputs.use_qemu == 'true' }}
 
 jobs:
   build-wheels:


### PR DESCRIPTION
From experience with a few releases: It is a weird pattern to create a release just to trigger the build. So I would rather trigger the build with a manual trigger and create the GH release once the PyPI release was successful.