### PR TITLE
Fix  `git clang-format` execution on Windows

### DIFF
--- a/clang_format/__init__.py
+++ b/clang_format/__init__.py
@@ -3,9 +3,18 @@ import subprocess
 import sys
 
 
+def _get_executable(name):
+    return os.path.join(os.path.dirname(__file__), "data", "bin", name)
+
 def _run(name):
-    executable = os.path.join(os.path.dirname(__file__), "data", "bin", name)
+    executable = _get_executable(name)
     return subprocess.call([executable] + sys.argv[1:])
+
+def _run_python(name):
+    executable = _get_executable(name)
+    # as MS Windows is not able to run Python scripts directly by name,
+    # we have to call the interpreter and pass the script as parameter
+    return subprocess.call([sys.executable, executable] + sys.argv[1:])
 
 
 def clang_format():
@@ -13,8 +22,8 @@ def clang_format():
 
 
 def clang_format_diff():
-    raise SystemExit(_run("clang-format-diff.py"))
+    raise SystemExit(_run_python("clang-format-diff.py"))
 
 
 def git_clang_format():
-    raise SystemExit(_run("git-clang-format"))
+    raise SystemExit(_run_python("git-clang-format"))

--- a/clang_format/__init__.py
+++ b/clang_format/__init__.py
@@ -11,10 +11,10 @@ def _run(name):
     return subprocess.call([executable] + sys.argv[1:])
 
 def _run_python(name):
-    executable = _get_executable(name)
+    script = _get_executable(name)
     # as MS Windows is not able to run Python scripts directly by name,
     # we have to call the interpreter and pass the script as parameter
-    return subprocess.call([sys.executable, executable] + sys.argv[1:])
+    return subprocess.call([sys.executable, script] + sys.argv[1:])
 
 
 def clang_format():


### PR DESCRIPTION
## Problem description
MS Windowss, unlike Linux/UNIIX, is not able to execute a Python file directly, instead, the Python interpreter has to be explicitely called with the script as argument (`python git-clang-format`).

Unfortunately, the previous implementation tried to call the Python script `git-clang-format` directly instead of calling the interpreter, which lead to an os exception:
```
PS C:\Users\username\directory> git clang-format
Traceback (most recent call last):
  File "C:\Program Files\Python37\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "C:\Program Files\Python37\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Users\username\directory\.venv\Scripts\git-clang-format.exe\__main__.py", line 7, in <module>
  File "c:\users\username\directory\.venv\lib\site-packages\clang_format\__init__.py", line 20, in git_clang_format
  File "c:\users\username\directory\.venv\lib\site-packages\clang_format\__init__.py", line 8, in _run
  File "C:\Program Files\Python37\lib\subprocess.py", line 323, in call
    with Popen(*popenargs, **kwargs) as p:
  File "C:\Program Files\Python37\lib\subprocess.py", line 775, in __init__
    restore_signals, start_new_session)
  File "C:\Program Files\Python37\lib\subprocess.py", line 1178, in _execute_child
    startupinfo)
OSError: [WinError 193] %1 ist keine zulässige Win32-Anwendung
```

## Reproduction steps
 - `pip install clang-format`
 - run `git clang-format` or `clang-format-diff`

## Solution
In case of Python scripts (namely `clang-format-diff.py` and  `git-clang-format`)  the package `__init__.py` calls not just the script (`[executable] + ...`), instead the currently used Python interpreter is called with the script as argument (`[sys.executable, script] + ...`).

## Risks:
 - breaking script execution on untested systems

## Tested
Tests already performed:
- local test of patched clang-format package on Windows 10:
  -  `git clang-format` 
  - `clang-format-diff`

## Tests required
Before completing the PR, the following tests should be considered:
- [ ] test on some Linux platform
- [ ] test on macOS

## ToDo
 - Add to CI test suite in future