### PR TITLE
Do not repair MacOS wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,6 @@ before-test = [
 ]
 test-requires = ["pytest", "pytest-git"]
 test-command = "pytest {package}/test"
+
+[tool.cibuildwheel.macos]
+repair-wheel-command = ""


### PR DESCRIPTION
delocator will error out although our wheels work fine when emulated on Apple Silicon.