### PR TITLE
Add mac arm64 wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,15 +52,15 @@ jobs:
             arch: "x86"
             use_qemu: false
             skip: ""
-          # note for future reference: why not separate x86_64 / arm64 macos builds?
-          # - building clang-format involves building llvm-tblgen and clang-tblgen binaries
-          # - these binaries are then executed as part of the build process
-          # - if we build for arm64 on an intel cpu it cannot execute these binaries and the build fails
           - os: macos-11
-            arch: "universal2"
+            arch: "x86_64"
             use_qemu: false
             skip: ""
-            cmake_osx_architectures: "x86_64;arm64"
+            # SSC self-hosted mac arm64 runner
+          - os: macos-arm64-ssc
+            arch: "arm64"
+            use_qemu: false
+            skip: ""
 
     steps:
     - uses: actions/checkout@v4
@@ -86,7 +86,6 @@ jobs:
       env:
         CIBW_ARCHS: "${{ matrix.arch }}"
         CIBW_SKIP: "${{ matrix.skip }}"
-        CIBW_ENVIRONMENT: 'CMAKE_OSX_ARCHITECTURES="${{ matrix.cmake_osx_architectures }}"'
 
     - uses: actions/upload-artifact@v3
       if: (!matrix.use_qemu) || fromJSON(env.USE_QEMU)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,10 @@ requires = ["setuptools>=42", "wheel", "scikit-build", "cmake>=3.16", "ninja; pl
 # Super-verbose output for debugging purpose
 build-verbosity = 3
 
-# We restrict ourselves to CPython 3.8 and then repair the wheels to be
+# We restrict ourselves to CPython 3.9 and then repair the wheels to be
 # independent of the Python version - I have not found a different solution
 # within cibuildwheel to achieve this.
-build = "cp38-*"
+build = "cp39-*"
 
 # Testing commands for our wheels
 before-test = [

--- a/setup.py
+++ b/setup.py
@@ -29,14 +29,6 @@ def get_version():
         else:
             return f"{parsed['CLANG_FORMAT_VERSION']}.{parsed['CLANG_FORMAT_WHEEL_VERSION']}"
 
-def get_cmake_args_from_env():
-    cmake_args = []
-    for cmake_arg in ["CMAKE_OSX_ARCHITECTURES"]:
-        cmake_arg_value = os.environ.get(cmake_arg)
-        if cmake_arg_value:
-            cmake_args.append(f"-D{cmake_arg}={cmake_arg_value}")
-    return cmake_args
-
 # Parse the given README file
 with open("README.md", "r") as readme_file:
     readme = readme_file.read()
@@ -75,5 +67,4 @@ setup(
         "Topic :: Software Development :: Quality Assurance",
     ],
     license="Apache 2.0",
-    cmake_args=get_cmake_args_from_env(),
 )


### PR DESCRIPTION
- use SSC self-hosted mac arm64 runner to build arm64 wheels
- only build x86_64 wheels on x86_64 macos-11 runner
- use python 3.9 as 3.8 requires rosetta to run on arm64 mac
- remove CMAKE_OSX_ARCHITECTURES logic as it is no longer required
