### PR TITLE
Do release workflow on tagged commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,10 @@
 name: Build + Release Wheels
 
 on:
+  push:
+    tags:
+      - 'v?[0-9]+.[0-9]+.[0-9]+'
+      - 'v?[0-9]+.[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
     inputs:
       use_qemu:
@@ -161,6 +165,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      contents: write
     if: github.repository_owner == 'ssciwr'
 
     steps:
@@ -179,3 +184,7 @@ jobs:
         if: github.event.inputs.deploy_to_testpypi == 'true'
         with:
           repository-url: https://test.pypi.org/legacy/
+
+      - name: GitHub release for tagged commits
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')

--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ In order to add a new release, the following steps are necessary:
 
 * Edit the [version file](https://github.com/ssciwr/clang-format-wheel/blob/main/clang-format_version.txt)
   * In the form `llvm_version.wheel_version`, e.g. `18.0.2.1`
-* Make a GitHub release to trigger the [GitHub Actions release workflow](https://github.com/ssciwr/clang-format-wheel/actions/workflows/release.yml). Alternatively, the workflow can be triggered manually.
+* Tag the commit with this version to trigger the [GitHub Actions release workflow](https://github.com/ssciwr/clang-format-wheel/actions/workflows/release.yml)
+  * e.g. `git tag v18.0.2.1 && git push origin v18.0.2.1`
+
+Alternatively, the workflow can be triggered manually:
 
 On manual triggers, the following input variables are available:
 * `use_qemu`: Whether to build targets that require emulation (default: `true`)


### PR DESCRIPTION
- make release process atomic
  - github release is automatically made after successful build & PyPI upload
  - if the build fails then no release is made
- allows new releases to be made from the command line
