### PR TITLE
Use windows-2019 runner in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,10 +55,10 @@ jobs:
             platform: "musllinux"
             arch: "i686"
           # windows
-          - os: windows-latest
+          - os: windows-2019
             platform: "win"
             arch: "AMD64"
-          - os: windows-latest
+          - os: windows-2019
             platform: "win"
             arch: "x86"
           # macos


### PR DESCRIPTION
- llvm build fails on windows-2022
- underlying issue is unclear but this is a short term workaround
- resolves #104
