### PR TITLE
Use GHA ARM runners to build aarch64 wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,8 @@ jobs:
 
     strategy:
       matrix:
-        # emulated linux: generate 6 matrix combinations with qemu on ubuntu:
-        arch: ["aarch64", "ppc64le", "s390x"]
+        # emulated linux: generate 4 matrix combinations with qemu on ubuntu:
+        arch: ["ppc64le", "s390x"]
         platform: ["manylinux", "musllinux"]
         os: [ubuntu-latest]
         emulation: ["qemu"]
@@ -54,6 +54,12 @@ jobs:
           - os: ubuntu-latest
             platform: "musllinux"
             arch: "i686"
+          - os: ubuntu-24.04-arm
+            platform: "manylinux"
+            arch: "aarch64"
+          - os: ubuntu-24.04-arm
+            platform: "musllinux"
+            arch: "aarch64"
           # windows
           - os: windows-2019
             platform: "win"


### PR DESCRIPTION
GitHub has (finally) made [arm hosted runners available for public repositories](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/)!

So far I've seen it significantly speeds up aarch64 build times compared to using QEMU, making them take roughly as long as their x86 counterparts.

From my [test run with the updated build matrix](https://github.com/nightlark/clang-format-wheel/actions/runs/12846203695/job/35821121117):
* manylinux
  - x86_64 took 17m 33s
  - native aarch64 took 12m 44s
  - qemu aarch64 build took 4h 17m 6s
* musllinux
  - x86_64 took 23m 6s
  - native aarch64 took 14m 24s
  - qemu aarch64 build took 4h 18m 24s