### PR TITLE
Add dev dependency-group for installing pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ ninja.version = ">=1.10.0"
 cmake.verbose = true
 logging.level = "DEBUG"
 
+[dependency-groups]
+dev = ["pytest"]
+
 [tool.cibuildwheel]
 # Super-verbose output for debugging purpose
 build-verbosity = 3


### PR DESCRIPTION
Dependency Groups ([PEP 735](https://peps.python.org/pep-0735/)) are a relatively new Python feature that gives a standard way to specify package requirements in `pyproject.toml` files, in a way that won't show up in the built wheels. It basically gives an alternative to creating arbitrarily named requirements.txt files.