### PR TITLE
Use QEMU v8 for emulated platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,8 @@ jobs:
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3.2.0
+      with:
+        image: tonistiigi/binfmt:qemu-v8.1.5
       if: runner.os == 'Linux' && matrix.emulation == 'qemu'
 
     - name: Build wheels


### PR DESCRIPTION
Something has changed, potentially related to some piece of software installed on the standard GitHub Actions runner image that is causing arbitrary programs running under qemu emulation to segfault. It doesn't look like there was any update to the manylinux images for these platforms that would cause this, so the root cause is still a mystery.

Switching to using the binfmt QEMU v8 images seems to resolve the issue. Or at least using v8 makes the segfaults infrequent enough that builds are at least able to finish (builds with v7 of QEMU segfault consistently, v8 is at least able to run builds to completion and I haven't seen segfaults yet... there's just not enough data yet to say conclusively that there will never be intermittent segfaults).

Resolves #124