### PR TITLE
Add Armv7l build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,8 @@ jobs:
 
     strategy:
       matrix:
-        # emulated linux: generate 4 matrix combinations with qemu on ubuntu:
-        arch: ["ppc64le", "s390x"]
+        # emulated linux: generate 6 matrix combinations with qemu on ubuntu:
+        arch: ["ppc64le", "s390x", "armv7l"]
         platform: ["manylinux", "musllinux"]
         os: [ubuntu-latest]
         emulation: ["qemu"]
@@ -110,7 +110,7 @@ jobs:
       if: runner.os == 'Linux' && matrix.emulation == 'qemu'
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.23
+      uses: pypa/cibuildwheel@v3.0
       env:
         CIBW_ARCHS: "${{ matrix.arch }}"
         # restrict to a single Python version as wheel does not depend on Python:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,8 @@ jobs:
 
     strategy:
       matrix:
-        # emulated linux: generate 6 matrix combinations with qemu on ubuntu:
-        arch: ["ppc64le", "s390x", "armv7l"]
+        # emulated linux: generate 4 matrix combinations with qemu on ubuntu:
+        arch: ["ppc64le", "s390x"]
         platform: ["manylinux", "musllinux"]
         os: [ubuntu-latest]
         emulation: ["qemu"]
@@ -60,6 +60,12 @@ jobs:
           - os: ubuntu-24.04-arm
             platform: "musllinux"
             arch: "aarch64"
+          - os: ubuntu-24.04-arm
+            platform: "manylinux"
+            arch: "armv7l"
+          - os: ubuntu-24.04-arm
+            platform: "musllinux"
+            arch: "armv7l"
           # windows
           - os: windows-2019
             platform: "win"


### PR DESCRIPTION
- uses arm aarch64 runners to build armv7l binary without emulation
- bump cibuildwheel version
- resolves #136